### PR TITLE
feat: #1 Reservation Service 보일러플레이트 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### macOS ###
+.DS_Store
+
+### Environment ###
+.env
+*.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+COPY build/libs/opentraum-reservation-service-*.jar app.jar
+
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+
+EXPOSE 8084
+
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.10'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.opentraum'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Spring WebFlux (Reactive Web)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // R2DBC (Reactive DB - PostgreSQL)
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+
+    // Redis Reactive (Queue / Distributed Lock)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+    // Kafka (Event Consumption + Production)
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Actuator + Prometheus (Monitoring)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opentraum-reservation-service'

--- a/src/main/java/com/opentraum/reservation/ReservationServiceApplication.java
+++ b/src/main/java/com/opentraum/reservation/ReservationServiceApplication.java
@@ -1,0 +1,12 @@
+package com.opentraum.reservation;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReservationServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReservationServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/opentraum/reservation/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/reservation/config/KafkaConfig.java
@@ -1,0 +1,70 @@
+package com.opentraum.reservation.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    // ===== Producer =====
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // ===== Consumer =====
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(3);
+        return factory;
+    }
+}

--- a/src/main/java/com/opentraum/reservation/config/R2dbcConfig.java
+++ b/src/main/java/com/opentraum/reservation/config/R2dbcConfig.java
@@ -1,0 +1,11 @@
+package com.opentraum.reservation.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+@Configuration
+@EnableR2dbcRepositories(basePackages = "com.opentraum.reservation.domain.repository")
+@EnableR2dbcAuditing
+public class R2dbcConfig {
+}

--- a/src/main/java/com/opentraum/reservation/config/RedisConfig.java
+++ b/src/main/java/com/opentraum/reservation/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.opentraum.reservation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public ReactiveStringRedisTemplate reactiveStringRedisTemplate(
+            ReactiveRedisConnectionFactory connectionFactory) {
+        return new ReactiveStringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
+            ReactiveRedisConnectionFactory connectionFactory) {
+        RedisSerializationContext<String, String> context =
+                RedisSerializationContext.<String, String>newSerializationContext(
+                                new StringRedisSerializer())
+                        .build();
+        return new ReactiveRedisTemplate<>(connectionFactory, context);
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/controller/QueueController.java
+++ b/src/main/java/com/opentraum/reservation/domain/controller/QueueController.java
@@ -1,0 +1,56 @@
+package com.opentraum.reservation.domain.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.opentraum.reservation.domain.dto.QueueStatusResponse;
+import com.opentraum.reservation.domain.service.QueueService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@RequiredArgsConstructor
+public class QueueController {
+
+    private final QueueService queueService;
+
+    @PostMapping("/enter")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<QueueStatusResponse> enterQueue(
+            @RequestParam Long userId,
+            @RequestParam Long eventId,
+            @RequestParam Long tenantId) {
+        return queueService.enterQueue(userId, eventId, tenantId);
+    }
+
+    @GetMapping("/position")
+    public Mono<QueueStatusResponse> getQueuePosition(
+            @RequestParam Long userId,
+            @RequestParam Long eventId,
+            @RequestParam Long tenantId) {
+        return queueService.getQueuePosition(userId, eventId, tenantId);
+    }
+
+    @DeleteMapping("/leave")
+    public Mono<Boolean> leaveQueue(
+            @RequestParam Long userId,
+            @RequestParam Long eventId,
+            @RequestParam Long tenantId) {
+        return queueService.leaveQueue(userId, eventId, tenantId);
+    }
+
+    @GetMapping("/size")
+    public Mono<Long> getQueueSize(
+            @RequestParam Long eventId,
+            @RequestParam Long tenantId) {
+        return queueService.getQueueSize(eventId, tenantId);
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/controller/ReservationController.java
+++ b/src/main/java/com/opentraum/reservation/domain/controller/ReservationController.java
@@ -1,0 +1,56 @@
+package com.opentraum.reservation.domain.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.opentraum.reservation.domain.dto.ReservationRequest;
+import com.opentraum.reservation.domain.dto.ReservationResponse;
+import com.opentraum.reservation.domain.service.ReservationService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<ReservationResponse> createReservation(@RequestBody ReservationRequest request) {
+        return reservationService.createReservation(request);
+    }
+
+    @GetMapping("/{id}")
+    public Mono<ReservationResponse> getReservation(@PathVariable Long id) {
+        return reservationService.getReservation(id);
+    }
+
+    @PutMapping("/{id}/confirm")
+    public Mono<ReservationResponse> confirmReservation(@PathVariable Long id) {
+        return reservationService.confirmReservation(id);
+    }
+
+    @PutMapping("/{id}/cancel")
+    public Mono<ReservationResponse> cancelReservation(@PathVariable Long id) {
+        return reservationService.cancelReservation(id);
+    }
+
+    @GetMapping
+    public Flux<ReservationResponse> getReservationsByEvent(
+            @RequestParam Long eventId,
+            @RequestParam Long tenantId) {
+        return reservationService.getReservationsByEvent(eventId, tenantId);
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/dto/QueueStatusResponse.java
+++ b/src/main/java/com/opentraum/reservation/domain/dto/QueueStatusResponse.java
@@ -1,0 +1,7 @@
+package com.opentraum.reservation.domain.dto;
+
+public record QueueStatusResponse(
+        Long position,
+        Long estimatedWaitTime
+) {
+}

--- a/src/main/java/com/opentraum/reservation/domain/dto/ReservationRequest.java
+++ b/src/main/java/com/opentraum/reservation/domain/dto/ReservationRequest.java
@@ -1,0 +1,9 @@
+package com.opentraum.reservation.domain.dto;
+
+public record ReservationRequest(
+        Long userId,
+        Long eventId,
+        Long seatId,
+        Long tenantId
+) {
+}

--- a/src/main/java/com/opentraum/reservation/domain/dto/ReservationResponse.java
+++ b/src/main/java/com/opentraum/reservation/domain/dto/ReservationResponse.java
@@ -1,0 +1,30 @@
+package com.opentraum.reservation.domain.dto;
+
+import java.time.LocalDateTime;
+
+import com.opentraum.reservation.domain.entity.Reservation;
+
+public record ReservationResponse(
+        Long id,
+        Long userId,
+        Long eventId,
+        Long seatId,
+        Long tenantId,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static ReservationResponse from(Reservation reservation) {
+        return new ReservationResponse(
+                reservation.getId(),
+                reservation.getUserId(),
+                reservation.getEventId(),
+                reservation.getSeatId(),
+                reservation.getTenantId(),
+                reservation.getStatus().name(),
+                reservation.getCreatedAt(),
+                reservation.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/entity/QueueEntry.java
+++ b/src/main/java/com/opentraum/reservation/domain/entity/QueueEntry.java
@@ -1,0 +1,49 @@
+package com.opentraum.reservation.domain.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Table("queue_entries")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueueEntry {
+
+    @Id
+    private Long id;
+
+    @Column("user_id")
+    private Long userId;
+
+    @Column("event_id")
+    private Long eventId;
+
+    @Column("tenant_id")
+    private Long tenantId;
+
+    private Long position;
+
+    @Builder.Default
+    private QueueStatus status = QueueStatus.WAITING;
+
+    @Column("entered_at")
+    private LocalDateTime enteredAt;
+
+    public enum QueueStatus {
+        WAITING,
+        PROCESSING,
+        COMPLETED,
+        EXPIRED
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/opentraum/reservation/domain/entity/Reservation.java
@@ -1,0 +1,57 @@
+package com.opentraum.reservation.domain.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Table("reservations")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reservation {
+
+    @Id
+    private Long id;
+
+    @Column("user_id")
+    private Long userId;
+
+    @Column("event_id")
+    private Long eventId;
+
+    @Column("seat_id")
+    private Long seatId;
+
+    @Column("tenant_id")
+    private Long tenantId;
+
+    @Builder.Default
+    private ReservationStatus status = ReservationStatus.PENDING;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum ReservationStatus {
+        PENDING,
+        CONFIRMED,
+        CANCELLED,
+        EXPIRED
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/opentraum/reservation/domain/repository/ReservationRepository.java
@@ -1,0 +1,21 @@
+package com.opentraum.reservation.domain.repository;
+
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.stereotype.Repository;
+
+import com.opentraum.reservation.domain.entity.Reservation;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public interface ReservationRepository extends R2dbcRepository<Reservation, Long> {
+
+    Flux<Reservation> findByUserIdAndEventId(Long userId, Long eventId);
+
+    Flux<Reservation> findByEventIdAndTenantId(Long eventId, Long tenantId);
+
+    Mono<Reservation> findByUserIdAndEventIdAndSeatId(Long userId, Long eventId, Long seatId);
+
+    Flux<Reservation> findByTenantId(Long tenantId);
+}

--- a/src/main/java/com/opentraum/reservation/domain/service/QueueService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/QueueService.java
@@ -1,0 +1,16 @@
+package com.opentraum.reservation.domain.service;
+
+import com.opentraum.reservation.domain.dto.QueueStatusResponse;
+
+import reactor.core.publisher.Mono;
+
+public interface QueueService {
+
+    Mono<QueueStatusResponse> enterQueue(Long userId, Long eventId, Long tenantId);
+
+    Mono<QueueStatusResponse> getQueuePosition(Long userId, Long eventId, Long tenantId);
+
+    Mono<Boolean> leaveQueue(Long userId, Long eventId, Long tenantId);
+
+    Mono<Long> getQueueSize(Long eventId, Long tenantId);
+}

--- a/src/main/java/com/opentraum/reservation/domain/service/QueueServiceImpl.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/QueueServiceImpl.java
@@ -1,0 +1,83 @@
+package com.opentraum.reservation.domain.service;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.opentraum.reservation.domain.dto.QueueStatusResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QueueServiceImpl implements QueueService {
+
+    private final ReactiveStringRedisTemplate redisTemplate;
+
+    private static final String QUEUE_KEY_PREFIX = "queue:event:";
+    private static final long ESTIMATED_WAIT_PER_POSITION_SECONDS = 5;
+
+    private String buildQueueKey(Long eventId, Long tenantId) {
+        return QUEUE_KEY_PREFIX + tenantId + ":" + eventId;
+    }
+
+    private String buildMemberValue(Long userId) {
+        return String.valueOf(userId);
+    }
+
+    @Override
+    public Mono<QueueStatusResponse> enterQueue(Long userId, Long eventId, Long tenantId) {
+        String queueKey = buildQueueKey(eventId, tenantId);
+        String member = buildMemberValue(userId);
+        double score = System.currentTimeMillis();
+
+        return redisTemplate.opsForZSet()
+                .addIfAbsent(queueKey, member, score)
+                .flatMap(added -> {
+                    if (Boolean.TRUE.equals(added)) {
+                        log.info("User {} entered queue for event {} (tenant {})", userId, eventId, tenantId);
+                    }
+                    return getQueuePosition(userId, eventId, tenantId);
+                });
+    }
+
+    @Override
+    public Mono<QueueStatusResponse> getQueuePosition(Long userId, Long eventId, Long tenantId) {
+        String queueKey = buildQueueKey(eventId, tenantId);
+        String member = buildMemberValue(userId);
+
+        return redisTemplate.opsForZSet()
+                .rank(queueKey, member)
+                .map(rank -> {
+                    long position = rank + 1;
+                    long estimatedWait = position * ESTIMATED_WAIT_PER_POSITION_SECONDS;
+                    return new QueueStatusResponse(position, estimatedWait);
+                })
+                .switchIfEmpty(Mono.error(
+                        new IllegalArgumentException("User " + userId + " is not in the queue for event " + eventId)));
+    }
+
+    @Override
+    public Mono<Boolean> leaveQueue(Long userId, Long eventId, Long tenantId) {
+        String queueKey = buildQueueKey(eventId, tenantId);
+        String member = buildMemberValue(userId);
+
+        return redisTemplate.opsForZSet()
+                .remove(queueKey, member)
+                .map(removed -> {
+                    if (removed > 0) {
+                        log.info("User {} left queue for event {} (tenant {})", userId, eventId, tenantId);
+                        return true;
+                    }
+                    return false;
+                });
+    }
+
+    @Override
+    public Mono<Long> getQueueSize(Long eventId, Long tenantId) {
+        String queueKey = buildQueueKey(eventId, tenantId);
+        return redisTemplate.opsForZSet().size(queueKey);
+    }
+}

--- a/src/main/java/com/opentraum/reservation/domain/service/ReservationService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/ReservationService.java
@@ -1,0 +1,20 @@
+package com.opentraum.reservation.domain.service;
+
+import com.opentraum.reservation.domain.dto.ReservationRequest;
+import com.opentraum.reservation.domain.dto.ReservationResponse;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ReservationService {
+
+    Mono<ReservationResponse> createReservation(ReservationRequest request);
+
+    Mono<ReservationResponse> getReservation(Long id);
+
+    Mono<ReservationResponse> confirmReservation(Long id);
+
+    Mono<ReservationResponse> cancelReservation(Long id);
+
+    Flux<ReservationResponse> getReservationsByEvent(Long eventId, Long tenantId);
+}

--- a/src/main/java/com/opentraum/reservation/domain/service/ReservationServiceImpl.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/ReservationServiceImpl.java
@@ -1,0 +1,99 @@
+package com.opentraum.reservation.domain.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.opentraum.reservation.domain.dto.ReservationRequest;
+import com.opentraum.reservation.domain.dto.ReservationResponse;
+import com.opentraum.reservation.domain.entity.Reservation;
+import com.opentraum.reservation.domain.entity.Reservation.ReservationStatus;
+import com.opentraum.reservation.domain.repository.ReservationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationServiceImpl implements ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Override
+    @Transactional
+    public Mono<ReservationResponse> createReservation(ReservationRequest request) {
+        Reservation reservation = Reservation.builder()
+                .userId(request.userId())
+                .eventId(request.eventId())
+                .seatId(request.seatId())
+                .tenantId(request.tenantId())
+                .status(ReservationStatus.PENDING)
+                .build();
+
+        return reservationRepository.save(reservation)
+                .doOnSuccess(saved -> {
+                    log.info("Reservation created: id={}, eventId={}, userId={}",
+                            saved.getId(), saved.getEventId(), saved.getUserId());
+                    kafkaTemplate.send("reservation-events",
+                            String.valueOf(saved.getId()),
+                            String.format("{\"type\":\"RESERVATION_CREATED\",\"reservationId\":%d,\"eventId\":%d,\"seatId\":%d,\"tenantId\":%d}",
+                                    saved.getId(), saved.getEventId(), saved.getSeatId(), saved.getTenantId()));
+                })
+                .map(ReservationResponse::from);
+    }
+
+    @Override
+    public Mono<ReservationResponse> getReservation(Long id) {
+        return reservationRepository.findById(id)
+                .map(ReservationResponse::from)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Reservation not found: " + id)));
+    }
+
+    @Override
+    @Transactional
+    public Mono<ReservationResponse> confirmReservation(Long id) {
+        return reservationRepository.findById(id)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Reservation not found: " + id)))
+                .flatMap(reservation -> {
+                    reservation.setStatus(ReservationStatus.CONFIRMED);
+                    return reservationRepository.save(reservation);
+                })
+                .doOnSuccess(confirmed -> {
+                    log.info("Reservation confirmed: id={}", confirmed.getId());
+                    kafkaTemplate.send("reservation-events",
+                            String.valueOf(confirmed.getId()),
+                            String.format("{\"type\":\"RESERVATION_CONFIRMED\",\"reservationId\":%d,\"eventId\":%d,\"tenantId\":%d}",
+                                    confirmed.getId(), confirmed.getEventId(), confirmed.getTenantId()));
+                })
+                .map(ReservationResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public Mono<ReservationResponse> cancelReservation(Long id) {
+        return reservationRepository.findById(id)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Reservation not found: " + id)))
+                .flatMap(reservation -> {
+                    reservation.setStatus(ReservationStatus.CANCELLED);
+                    return reservationRepository.save(reservation);
+                })
+                .doOnSuccess(cancelled -> {
+                    log.info("Reservation cancelled: id={}", cancelled.getId());
+                    kafkaTemplate.send("reservation-events",
+                            String.valueOf(cancelled.getId()),
+                            String.format("{\"type\":\"RESERVATION_CANCELLED\",\"reservationId\":%d,\"eventId\":%d,\"seatId\":%d,\"tenantId\":%d}",
+                                    cancelled.getId(), cancelled.getEventId(), cancelled.getSeatId(), cancelled.getTenantId()));
+                })
+                .map(ReservationResponse::from);
+    }
+
+    @Override
+    public Flux<ReservationResponse> getReservationsByEvent(Long eventId, Long tenantId) {
+        return reservationRepository.findByEventIdAndTenantId(eventId, tenantId)
+                .map(ReservationResponse::from);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,60 @@
+server:
+  port: 8084
+
+spring:
+  application:
+    name: opentraum-reservation-service
+
+  # R2DBC - PostgreSQL
+  r2dbc:
+    url: r2dbc:postgresql://localhost:5432/opentraum_reservation
+    username: ${DB_USERNAME:opentraum}
+    password: ${DB_PASSWORD:opentraum}
+    pool:
+      initial-size: 5
+      max-size: 20
+      max-idle-time: 30m
+
+  # Redis (Queue / Distributed Lock)
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
+  # Kafka
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: reservation-service-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+    producer:
+      acks: all
+      retries: 3
+
+  # SQL Init
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+
+# Actuator + Prometheus
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+# Logging
+logging:
+  level:
+    com.opentraum.reservation: DEBUG
+    org.springframework.r2dbc: DEBUG
+    org.springframework.data.redis: DEBUG

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS reservations (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT       NOT NULL,
+    event_id    BIGINT       NOT NULL,
+    seat_id     BIGINT       NOT NULL,
+    tenant_id   BIGINT       NOT NULL,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uk_reservation_user_event_seat UNIQUE (user_id, event_id, seat_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reservations_event_tenant ON reservations (event_id, tenant_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_user_event ON reservations (user_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_status ON reservations (status);
+
+CREATE TABLE IF NOT EXISTS queue_entries (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT       NOT NULL,
+    event_id    BIGINT       NOT NULL,
+    tenant_id   BIGINT       NOT NULL,
+    position    BIGINT,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'WAITING',
+    entered_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uk_queue_user_event UNIQUE (user_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_entries_event_tenant ON queue_entries (event_id, tenant_id);
+CREATE INDEX IF NOT EXISTS idx_queue_entries_status ON queue_entries (status);


### PR DESCRIPTION
## 개요
OpenTraum 예약 및 대기열 관리 서비스의 보일러플레이트를 구축합니다.

Closes #1

## 변경 사항

### 프로젝트 설정
- Spring Boot 3.5.10 + Java 21 + WebFlux + R2DBC + Redis Reactive + Kafka
- Gradle 8.12, Dockerfile 멀티 스테이지 빌드

### 도메인 모델
- **Reservation**: 예약 엔티티 (PENDING/CONFIRMED/CANCELLED/EXPIRED)
- **QueueEntry**: 대기열 엔티티 (WAITING/PROCESSING/COMPLETED/EXPIRED)

### 서비스 계층
- **ReservationService**: 예약 CRUD + Kafka 이벤트 발행
- **QueueService**: Redis Sorted Set 기반 대기열 (진입/위치조회/퇴장/크기)

### API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | /api/v1/reservations | 예약 생성 |
| GET | /api/v1/reservations/{id} | 예약 조회 |
| PUT | /api/v1/reservations/{id}/confirm | 예약 확인 |
| PUT | /api/v1/reservations/{id}/cancel | 예약 취소 |
| POST | /api/v1/queue/enter | 대기열 진입 |
| GET | /api/v1/queue/position | 대기열 위치 조회 |
| DELETE | /api/v1/queue/leave | 대기열 퇴장 |

### 인프라
- application.yml (포트 8084), schema.sql, Dockerfile

## 테스트 계획
- [ ] 프로젝트 빌드 성공 확인
- [ ] Actuator health endpoint 확인
- [ ] 예약 CRUD API 동작 확인
- [ ] Redis 대기열 진입/조회 확인