### PR TITLE
feat: #7 TrackPolicy 기반 트랙 접근 제어

### DIFF
--- a/src/main/java/com/opentraum/reservation/domain/client/dto/ScheduleInfo.java
+++ b/src/main/java/com/opentraum/reservation/domain/client/dto/ScheduleInfo.java
@@ -16,4 +16,5 @@ public class ScheduleInfo {
     private Long concertId;
     private LocalDateTime ticketOpenAt;
     private String status;
+    private String trackPolicy;
 }

--- a/src/main/java/com/opentraum/reservation/domain/service/LiveTrackService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/LiveTrackService.java
@@ -44,6 +44,9 @@ public class LiveTrackService {
         // 1. 티켓 오픈 시간 체크
         return eventServiceClient.findScheduleOrThrow(scheduleId)
                 .flatMap(schedule -> {
+                    if ("LOTTERY_ONLY".equals(schedule.getTrackPolicy())) {
+                        return Mono.error(new BusinessException(ErrorCode.TRACK_NOT_ALLOWED));
+                    }
                     LocalDateTime now = LocalDateTime.now();
                     if (now.isBefore(schedule.getTicketOpenAt())) {
                         return Mono.error(new BusinessException(ErrorCode.TICKET_NOT_OPENED));

--- a/src/main/java/com/opentraum/reservation/domain/service/LotteryTrackService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/LotteryTrackService.java
@@ -57,6 +57,9 @@ public class LotteryTrackService {
                 // 1. 추첨 트랙 시간대 체크
                 .then(eventServiceClient.findScheduleOrThrow(request.getScheduleId()))
                 .flatMap(schedule -> {
+                    if ("LIVE_ONLY".equals(schedule.getTrackPolicy())) {
+                        return Mono.error(new BusinessException(ErrorCode.TRACK_NOT_ALLOWED));
+                    }
                     LocalDateTime now = LocalDateTime.now();
                     LocalDateTime lotteryOpenAt = schedule.getTicketOpenAt().minusMinutes(ReservationConstants.LOTTERY_OPEN_MINUTES);
                     LocalDateTime lotteryEntryCloseAt = schedule.getTicketOpenAt().minusMinutes(ReservationConstants.LOTTERY_ENTRY_CLOSE_MINUTES);

--- a/src/main/java/com/opentraum/reservation/global/exception/ErrorCode.java
+++ b/src/main/java/com/opentraum/reservation/global/exception/ErrorCode.java
@@ -38,6 +38,8 @@ public enum ErrorCode {
     CANCELLATION_NOT_AVAILABLE(HttpStatus.FORBIDDEN, "T008", "추첨/라이브 트랙이 모두 마감된 후에만 취소 신청이 가능합니다"),
     CANCELLATION_WINDOW_EXPIRED(HttpStatus.FORBIDDEN, "T009", "취소 가능 기간이 지났습니다"),
 
+    TRACK_NOT_ALLOWED(HttpStatus.FORBIDDEN, "T010", "해당 배정 방식이 허용되지 않는 공연입니다"),
+
     UNAUTHORIZED(HttpStatus.FORBIDDEN, "A001", "접근 권한이 없습니다"),
     SEAT_HOLD_NOT_OWNED(HttpStatus.FORBIDDEN, "S006", "본인이 홀드한 좌석이 아닙니다"),
 


### PR DESCRIPTION
## 개요
event-service에 추가된 TrackPolicy를 기반으로 트랙 접근을 제어합니다.

closes #7

## 변경 사항 (4 files changed, +9 / -0)

### 수정
| 파일 | 변경 내용 |
|---|---|
| `ScheduleInfo.java` | `trackPolicy` 필드 추가 |
| `ErrorCode.java` | `TRACK_NOT_ALLOWED` (T010) 에러 코드 추가 |
| `LiveTrackService.java` | `LOTTERY_ONLY` 정책일 때 라이브 트랙 요청 거부 |
| `LotteryTrackService.java` | `LIVE_ONLY` 정책일 때 로터리 트랙 요청 거부 |

## 동작 방식
- event-service Internal API에서 `trackPolicy` 필드를 함께 반환
- `selectSeat()` 진입 시 `LOTTERY_ONLY`면 즉시 `TRACK_NOT_ALLOWED` 에러
- `createLotteryReservation()` 진입 시 `LIVE_ONLY`면 즉시 `TRACK_NOT_ALLOWED` 에러
- `DUAL_TRACK`은 기존과 동일하게 양 트랙 모두 허용

## 컴파일 검증
`./gradlew compileJava` ✅ BUILD SUCCESSFUL