### PR TITLE
feat: PostgreSQL → MariaDB 전환

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.gradle/
+build/
+.git/
+.github/
+*.md
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jdk-alpine AS builder
 
 WORKDIR /app
 
-COPY build/libs/opentraum-reservation-service-*.jar app.jar
+COPY gradle/ gradle/
+COPY gradlew .
+COPY build.gradle settings.gradle ./
 
-ENV JAVA_OPTS="-Xms256m -Xmx512m"
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+COPY src/ src/
+
+RUN ./gradlew bootJar --no-daemon -x test
+
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8084
 
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar app.jar"]
+ENTRYPOINT ["java", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,9 @@ dependencies {
     // Spring WebFlux (Reactive Web)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    // R2DBC (Reactive DB - PostgreSQL)
+    // R2DBC (Reactive DB - MariaDB)
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
-    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+    runtimeOnly 'io.asyncer:r2dbc-mysql:1.1.0'
 
     // Redis Reactive (Queue / Distributed Lock)
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -50,16 +50,16 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8084
-            initialDelaySeconds: 60
+            initialDelaySeconds: 90
             periodSeconds: 15
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8084
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
       restartPolicy: Always

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -41,10 +41,10 @@ spec:
               value: "opentraum"
           resources:
             requests:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "250m"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
           livenessProbe:
             httpGet:

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: reservation
 spec:
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: reservation
     spec:
+      terminationGracePeriodSeconds: 10
       imagePullSecrets:
         - name: harbor-secret
       containers:
@@ -40,27 +41,37 @@ spec:
               value: "opentraum"
             - name: SPRING_R2DBC_PASSWORD
               value: "opentraum"
+            - name: JAVA_OPTS
+              value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+            - name: SPRING_MAIN_LAZY_INITIALIZATION
+              value: "true"
           resources:
             requests:
               memory: "256Mi"
-              cpu: "250m"
+              cpu: "500m"
             limits:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8084
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 3
+            failureThreshold: 20
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8084
-            initialDelaySeconds: 90
-            periodSeconds: 15
-            timeoutSeconds: 5
-            failureThreshold: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8084
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
       restartPolicy: Always

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -25,7 +25,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: reservation-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:fa2e358ac579c5846f4f5381d58d1c690252f6b8
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:47c9329bd50dbac0e209fb8465504962af944647
           ports:
             - containerPort: 8084
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -25,7 +25,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: reservation-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:47c9329bd50dbac0e209fb8465504962af944647
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:ac9b402dad7ef8f035aa1e47080d8b1a2bfc1cc7
           ports:
             - containerPort: 8084
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -33,6 +33,12 @@ spec:
           env:
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://opentraum-postgres:5432/opentraum_reservation"
+            - name: SPRING_R2DBC_URL
+              value: "r2dbc:postgresql://opentraum-postgres:5432/opentraum_reservation"
+            - name: SPRING_R2DBC_USERNAME
+              value: "opentraum"
+            - name: SPRING_R2DBC_PASSWORD
+              value: "opentraum"
           resources:
             requests:
               memory: "128Mi"

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -23,7 +23,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: reservation-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:latest
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-reservation-service:fa2e358ac579c5846f4f5381d58d1c690252f6b8
           ports:
             - containerPort: 8084
               protocol: TCP

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,11 +5,11 @@ spring:
   application:
     name: opentraum-reservation-service
 
-  # R2DBC - PostgreSQL
+  # R2DBC - MariaDB
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_reservation
+    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/opentraum_reservation
     username: ${DB_USERNAME:opentraum}
-    password: ${DB_PASSWORD:opentraum}
+    password: ${DB_PASSWORD:opentraum123!}
     pool:
       initial-size: 5
       max-size: 20

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS reservations (
-    id                  BIGSERIAL PRIMARY KEY,
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id             BIGINT       NOT NULL,
     schedule_id         BIGINT       NOT NULL,
     tenant_id           BIGINT,
@@ -15,20 +15,21 @@ CREATE TABLE IF NOT EXISTS reservations (
 );
 
 CREATE TABLE IF NOT EXISTS reservation_seats (
-    id                  BIGSERIAL PRIMARY KEY,
-    reservation_id      BIGINT       NOT NULL REFERENCES reservations(id),
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    reservation_id      BIGINT       NOT NULL,
     seat_id             BIGINT,
     seat_number         VARCHAR(20),
     zone                VARCHAR(20),
     status              VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
     assigned_at         TIMESTAMP,
-    created_at          TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+    created_at          TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_reservation_seats_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_reservation_seats_seat_id
-    ON reservation_seats(seat_id) WHERE seat_id IS NOT NULL;
+CREATE INDEX idx_reservation_seats_seat_id
+    ON reservation_seats(seat_id);
 
-CREATE INDEX IF NOT EXISTS idx_reservations_user ON reservations(user_id);
-CREATE INDEX IF NOT EXISTS idx_reservations_schedule ON reservations(schedule_id);
-CREATE INDEX IF NOT EXISTS idx_reservations_status ON reservations(status);
-CREATE INDEX IF NOT EXISTS idx_reservation_seats_reservation ON reservation_seats(reservation_id);
+CREATE INDEX idx_reservations_user ON reservations(user_id);
+CREATE INDEX idx_reservations_schedule ON reservations(schedule_id);
+CREATE INDEX idx_reservations_status ON reservations(status);
+CREATE INDEX idx_reservation_seats_reservation ON reservation_seats(reservation_id);


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 드라이버 전환
- SKALA 미니프로젝트 1+2 (대량 요청 처리 + CDC) 대비

## Changes
- `r2dbc-postgresql` → `io.asyncer:r2dbc-mysql:1.1.0`
- connection string → `r2dbc:mariadb://opentraum-mariadb:3306`
- schema.sql MariaDB 호환 문법 전환

## Test plan
- [x] MariaDB Pod Running 확인
- [x] 서비스 Pod Running 확인 (새 이미지)
- [ ] /actuator/health 200 응답 확인
- [ ] CRUD API 정상 동작 확인