### PR TITLE
fix: 라이브 트랙 좌석 조회 빈 배열 반환 문제 해결 (#28)

### DIFF
--- a/src/main/java/com/opentraum/reservation/domain/service/LiveTrackService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/LiveTrackService.java
@@ -58,6 +58,7 @@ public class LiveTrackService {
     private final EventServiceClient eventServiceClient;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final OutboxService outboxService;
+    private final SeatPoolService seatPoolService;
 
     // 좌석 선택 (라이브 트랙). 플로우: 등급 선택 → 구역 선택 → 좌석 선택
     public Mono<SeatSelectionResponse> selectSeat(Long scheduleId, SeatSelectionRequest request, Long userId) {
@@ -268,26 +269,25 @@ public class LiveTrackService {
     }
 
     /**
-     * 한 구역의 선택 가능 좌석 번호 목록.
-     *
-     * <p>Wave 3: event-service에 "구역별 AVAILABLE 좌석 목록" 조회 API가 아직 없다.
-     * 현재는 등급·구역 검증만 수행하고 빈 목록을 반환한다. 프론트엔드는 좌석 맵 UI에서
-     * 전체 배치를 보여주고 클릭 시점에 {@link #selectSeat}의 event-service 조회로
-     * AVAILABLE 여부를 확인한다. 추후 event-service에 해당 API 추가 시 연결한다.
+     * 등급-구역 검증 후 공유 Redis 좌석 풀(seats:{scheduleId}:{zone})에서 잔여 좌석 번호 목록을 조회한다.
      */
     public Mono<List<String>> getAvailableSeats(Long scheduleId, String grade, String zone) {
         return eventServiceClient.validateGradeAndZone(scheduleId, grade, zone)
-                .thenReturn(List.of());
+                .then(seatPoolService.getAvailableSeats(scheduleId, zone).collectList());
     }
 
-    // 잔여석 존재 여부: event-service 잔여석 API 부재로 큐 마감 플래그만 확인
+    // 잔여석 존재 여부: 좌석 풀 전체 합산이 0보다 큰지 확인
     public Mono<Boolean> hasRemainingSeats(Long scheduleId) {
-        return isLiveTrackClosedByQueue(scheduleId).map(closed -> !closed);
+        return seatPoolService.getRemainingSeatsTotal(scheduleId)
+                .map(total -> total > 0);
     }
 
-    // 라이브 트랙 오픈 여부
+    // 라이브 트랙 오픈 여부: 잔여 좌석 + 큐 마감 플래그 둘 다 OK
     public Mono<Boolean> isLiveTrackOpen(Long scheduleId) {
-        return isLiveTrackClosedByQueue(scheduleId).map(closed -> !closed);
+        return hasRemainingSeats(scheduleId)
+                .flatMap(hasSeats -> hasSeats
+                        ? isLiveTrackClosedByQueue(scheduleId).map(closed -> !closed)
+                        : Mono.just(false));
     }
 
     public Mono<Boolean> isLiveTrackClosedByQueue(Long scheduleId) {

--- a/src/main/java/com/opentraum/reservation/domain/service/SeatPoolService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/SeatPoolService.java
@@ -6,6 +6,7 @@ import com.opentraum.reservation.global.util.RedisKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -14,7 +15,7 @@ import java.util.List;
 
 /**
  * Redis 기반 좌석 풀 관리 (공유 Redis 직접 접근).
- * Redis Key: seat-pool:{scheduleId}:{zone} (Set of seatNumber)
+ * Redis Key: seats:{scheduleId}:{zone} (Set of seatNumber, event-service와 공유)
  */
 @Slf4j
 @Service
@@ -25,24 +26,24 @@ public class SeatPoolService {
     private final EventServiceClient eventServiceClient;
 
     public Mono<Boolean> selectSeat(Long scheduleId, String zone, String seatNumber) {
-        String key = RedisKeyGenerator.seatPoolKey(scheduleId, zone);
+        String key = RedisKeyGenerator.seatsKey(scheduleId, zone);
         return redisTemplate.opsForSet().remove(key, seatNumber)
                 .map(removed -> removed > 0);
     }
 
     public Mono<Boolean> returnSeat(Long scheduleId, String zone, String seatNumber) {
-        String key = RedisKeyGenerator.seatPoolKey(scheduleId, zone);
+        String key = RedisKeyGenerator.seatsKey(scheduleId, zone);
         return redisTemplate.opsForSet().add(key, seatNumber)
                 .map(added -> added > 0);
     }
 
     public Flux<String> getAvailableSeats(Long scheduleId, String zone) {
-        String key = RedisKeyGenerator.seatPoolKey(scheduleId, zone);
+        String key = RedisKeyGenerator.seatsKey(scheduleId, zone);
         return redisTemplate.opsForSet().members(key);
     }
 
     public Mono<Long> getRemainingSeats(Long scheduleId, String zone) {
-        String key = RedisKeyGenerator.seatPoolKey(scheduleId, zone);
+        String key = RedisKeyGenerator.seatsKey(scheduleId, zone);
         return redisTemplate.opsForSet().size(key);
     }
 
@@ -54,10 +55,11 @@ public class SeatPoolService {
                 .reduce(0L, Long::sum);
     }
 
-    // 전체 구역 잔여석 합산 (SCAN 패턴 매칭 후 SCARD)
+    // 전체 구역 잔여석 합산 (SCAN 비차단 순회 후 SCARD)
     public Mono<Long> getRemainingSeatsTotal(Long scheduleId) {
-        String pattern = "seat-pool:" + scheduleId + ":*";
-        return redisTemplate.keys(pattern)
+        String pattern = "seats:" + scheduleId + ":*";
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+        return redisTemplate.scan(options)
                 .flatMap(key -> redisTemplate.opsForSet().size(key))
                 .reduce(0L, Long::sum)
                 .defaultIfEmpty(0L);

--- a/src/main/java/com/opentraum/reservation/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/opentraum/reservation/global/util/RedisKeyGenerator.java
@@ -50,8 +50,8 @@ public class RedisKeyGenerator {
         return String.format("stock:%d:%s", scheduleId, grade);
     }
 
-    public static String seatPoolKey(Long scheduleId, String zone) {
-        return String.format("seat-pool:%d:%s", scheduleId, zone);
+    public static String seatsKey(Long scheduleId, String zone) {
+        return String.format("seats:%d:%s", scheduleId, zone);
     }
 
     public static String holdKey(Long scheduleId, String zone, String seatNumber) {


### PR DESCRIPTION
## 배경 / 문제

E2E 테스트 중 발견. 어드민이 콘서트 생성 → 좌석 풀 초기화까지 정상이지만, CONSUMER가 라이브 트랙 좌석 조회 시 항상 **빈 배열 \`[]\`** 반환. 좌석 선택 → 결제 → 좌석 확정 라인 전체가 막힘. 시연 시나리오 4번 진행 불가.

이슈: #28

## 원인 (2가지)

### 1. Redis 키 형식 불일치
- event-service: \`seats:{scheduleId}:{zone}\` (좌석 풀 데이터 저장)
- reservation-service: \`seat-pool:{scheduleId}:{zone}\` (다른 키 조회)
- 같은 Redis 인스턴스 공유함에도 키가 달라 reservation이 좌석 데이터를 못 봄

### 2. LiveTrackService 메서드 stub 처리
- \`getAvailableSeats\`: 검증 후 항상 \`List.of()\` 반환
- \`hasRemainingSeats\`: 큐 마감 플래그만 확인, 실제 좌석 잔여 미확인
- \`isLiveTrackOpen\`: hasRemainingSeats와 사실상 동일

## 변경 내용

### \`RedisKeyGenerator.java\`
- \`seatPoolKey\` → \`seatsKey\`, 키 포맷 \`seat-pool:%d:%s\` → \`seats:%d:%s\` (event-service와 통일)

### \`SeatPoolService.java\`
- 호출처 4곳을 새 메서드명으로 갱신
- \`getRemainingSeatsTotal\`: 패턴 직접 사용 부분도 \`seats:\` 형식으로 통일
- **추가 최적화**: 운영 안티패턴인 \`KEYS\` 명령을 비차단 \`SCAN\` 으로 교체 (대규모 좌석 풀에서 Redis 블로킹 방지)
- javadoc 주석에 event-service와 키 공유 명시

### \`LiveTrackService.java\`
- \`SeatPoolService\` 의존성 주입 추가
- \`getAvailableSeats\`: SeatPoolService 호출로 실제 좌석 목록 반환
- \`hasRemainingSeats\`: SeatPoolService.getRemainingSeatsTotal 합산 결과 기반
- \`isLiveTrackOpen\`: 좌석 잔여 + 큐 마감 플래그 동시 검증

## 검증 (클러스터 배포 후 E2E)

| 호출 | 결과 |
|---|---|
| \`GET /api/v1/live/2?grade=R&zone=B\` | \`["1","2","3","4","5","6"]\` (Redis SCARD 6 일치) ✅ |
| \`GET /api/v1/live/2?grade=VIP&zone=A\` | \`["1","2","3","4"]\` (Redis SCARD 4 일치) ✅ |
| \`GET /api/v1/live/2/status\` | \`true\` (SCAN 합산 정상) ✅ |
| \`GET /api/v1/live/1/status\` | \`true\` (다른 schedule도 SCAN 정상) ✅ |

## 영향 범위

- 시연 시나리오 4번(소비자 예매 흐름) 진행 가능 상태로 복구
- 후속 작업(SeatAssignmentConsumer 등) 검증을 위한 선결 조건 해소

## Test plan

- [x] Gradle 컴파일 성공
- [x] 임시 이미지(\`fix-28-test\`)로 클러스터 배포 후 E2E 검증
- [x] Redis SCARD 결과와 API 응답 정합성 확인
- [ ] (머지 후) CI 빌드 → ArgoCD 자동 sync → 프로덕션 이미지로 재검증

Closes #28