### PR TITLE
fix: confirmLive에서 reservation_seats PENDING → ASSIGNED 전이 누락 (#30)

### DIFF
--- a/src/main/java/com/opentraum/reservation/domain/service/ReservationSagaService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/ReservationSagaService.java
@@ -41,6 +41,7 @@ public class ReservationSagaService {
     private final TransactionalOperator txOperator;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final CancellationWindowService cancellationWindowService;
+    private final LiveTrackService liveTrackService;
 
     /**
      * Live 예약 생성 + ReservationCreated 발행.
@@ -102,7 +103,7 @@ public class ReservationSagaService {
     }
 
     /**
-     * Live 결제 완료 확정: PENDING → PAID.
+     * Live 결제 완료 확정: reservation PENDING → PAID, reservation_seats PENDING → ASSIGNED.
      */
     public Mono<Void> confirmLive(String sagaId, Long reservationId, Long paymentId) {
         return reservationRepository.findById(reservationId)
@@ -114,7 +115,8 @@ public class ReservationSagaService {
                     reservation.setStatus(ReservationStatus.PAID.name());
                     reservation.setUpdatedAt(LocalDateTime.now());
                     return reservationRepository.save(reservation)
-                            .flatMap(saved -> publishConfirmed(saved, paymentId));
+                            .flatMap(saved -> liveTrackService.onPaymentCompleted(saved.getId())
+                                    .then(publishConfirmed(saved, paymentId)));
                 })
                 .as(txOperator::transactional)
                 .then();


### PR DESCRIPTION
## 배경 / 문제

LIVE 트랙 결제 완료 후 \`reservation.status\`는 PENDING → PAID로 정상 전이되지만,
\`reservation_seats.status\`는 PENDING으로 남아있어 좌석 확정이 완성되지 않았음.

이슈: #30

## 원인

\`ReservationSagaService.confirmLive\`가 \`reservations\` 엔티티만 update 하고
\`reservation_seats\`는 손대지 않음. \`LiveTrackService.onPaymentCompleted\` 메서드는
이미 정확히 그 동작(PENDING → ASSIGNED)을 구현하고 있으나 호출처가 0건이었다.

## 변경 내용

### \`ReservationSagaService.java\`
- \`LiveTrackService\` 의존성 주입 추가
- \`confirmLive\`에서 reservation save 후 \`liveTrackService.onPaymentCompleted(reservationId)\`
  를 같은 \`txOperator::transactional\` 경계 안에서 호출
- 호출 순서: reservation.save → seat ASSIGNED 전이 → outbox publishConfirmed
  (좌석 update 실패 시 outbox 발행 안 되도록 atomic 보장)

## 검증 (클러스터 임시 이미지 배포 후 E2E)

좌석 hold → SAGA 자동 결제(SeatHeldListener → PaymentSagaService → PortOne mock →
Outbox PaymentCompleted → opentraum.payment 토픽) → reservation \`PaymentEventListener\` →
\`confirmLive\` → reservation_seats ASSIGNED 까지 자동 흐름 검증:

\`\`\`json
{
  "id": 100, "scheduleId": 3, "status": "PAID",
  "seats": [{"zone":"B","seatNumber":"2","status":"ASSIGNED"}]
}
\`\`\`

## LOTTERY 제외 사유

\`confirmLottery\`는 reservation을 PAID_PENDING_SEAT로 두고 좌석은 batch
(\`assignSeatsToPaidLotteryAndMerge\`)에서 ASSIGNED로 일괄 배정하는 별도 디자인이라
이번 fix 범위에서 제외. 추첨 좌석 ASSIGNED는 기존 batch 흐름으로 정상 처리됨.

## Test plan

- [x] Gradle 컴파일 성공
- [x] 임시 이미지 배포 후 E2E 검증 (좌석 hold → 자동 결제 → ASSIGNED)
- [ ] (머지 후) CI 빌드 → ArgoCD 자동 sync → 정식 이미지 재검증

## 관련

- 시연 시나리오 4번 (소비자 예매→결제→좌석 확정) E2E 완성
- TOP 5 잔여 작업 #2의 진짜 해법

Closes #30