### PR TITLE
fix: 환불/취소 흐름에서 reservation_seats CANCELLED + outbox 누락 (#32)

### DIFF
--- a/src/main/java/com/opentraum/reservation/domain/service/ReservationSagaService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/ReservationSagaService.java
@@ -5,6 +5,7 @@ import com.opentraum.reservation.domain.entity.ReservationStatus;
 import com.opentraum.reservation.domain.entity.TrackType;
 import com.opentraum.reservation.domain.outbox.service.OutboxService;
 import com.opentraum.reservation.domain.repository.ReservationRepository;
+import com.opentraum.reservation.domain.repository.ReservationSeatRepository;
 import com.opentraum.reservation.domain.saga.SeatRef;
 import com.opentraum.reservation.global.exception.BusinessException;
 import com.opentraum.reservation.global.exception.ErrorCode;
@@ -37,6 +38,7 @@ public class ReservationSagaService {
     private static final String AGGREGATE_TYPE = "reservation";
 
     private final ReservationRepository reservationRepository;
+    private final ReservationSeatRepository reservationSeatRepository;
     private final OutboxService outboxService;
     private final TransactionalOperator txOperator;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
@@ -201,7 +203,8 @@ public class ReservationSagaService {
                         reservation.setStatus(ReservationStatus.CANCELLED.name());
                         reservation.setUpdatedAt(LocalDateTime.now());
                         Mono<Void> work = reservationRepository.save(reservation)
-                                .flatMap(saved -> publishCancelled(saved, "USER_CANCELLED"))
+                                .then(reservationSeatRepository.updateStatusToCancelledByReservationId(reservation.getId()))
+                                .then(publishCancelled(reservation, "USER_CANCELLED"))
                                 .then();
                         return txOperator.transactional(work);
                     }
@@ -214,7 +217,8 @@ public class ReservationSagaService {
     }
 
     /**
-     * RefundCompleted 수신: REFUNDED로 확정.
+     * RefundCompleted 수신: reservation REFUNDED + reservation_seats CANCELLED + ReservationCancelled outbox 발행.
+     * event-service가 outbox 이벤트로 좌석 풀 반환 + seats 테이블 AVAILABLE 전이를 batch 처리한다.
      */
     public Mono<Void> confirmRefund(String sagaId, Long reservationId) {
         return reservationRepository.findById(reservationId)
@@ -225,7 +229,10 @@ public class ReservationSagaService {
                     }
                     reservation.setStatus(ReservationStatus.REFUNDED.name());
                     reservation.setUpdatedAt(LocalDateTime.now());
-                    return reservationRepository.save(reservation).then();
+                    return reservationRepository.save(reservation)
+                            .then(reservationSeatRepository.updateStatusToCancelledByReservationId(reservationId))
+                            .then(publishCancelled(reservation, "USER_REFUND"))
+                            .then();
                 })
                 .as(txOperator::transactional)
                 .then();


### PR DESCRIPTION
## 배경 / 문제

사용자 취소 두 갈래 흐름(`userCancel` PENDING / `confirmRefund`)에서 reservation_seats 상태 전이 + ReservationCancelled outbox 발행 누락. 결과적으로 좌석이 ASSIGNED/PENDING으로 남아 좌석 풀로 반환되지 않음.

이슈: #32

## 변경 내용

### `ReservationSagaService.java`
- `ReservationSeatRepository` 의존성 주입
- `userCancel` PENDING 분기: 같은 트랜잭션에 좌석 CANCELLED 일괄 update 추가
- `confirmRefund`: 같은 트랜잭션에 좌석 CANCELLED + publishCancelled(USER_REFUND) 추가
- 기존 `updateStatusToCancelledByReservationId` 메서드 재사용 (ReservationCancelService와 동일 패턴)

## 검증 (임시 이미지 배포 E2E)

신규 사용자 → 좌석 선택 → SAGA 자동 결제 → reservation 103 (PAID/ASSIGNED) → DELETE → RefundConsumer → confirmRefund:

```json
{ "id": 103, "status": "REFUNDED", "seats": [{ "status": "CANCELLED" }] }
payment.status=REFUNDED
```

5초 안에 전체 SAGA 흐름 자동 완료 확인.

## Test plan

- [x] Gradle 컴파일 성공
- [x] 임시 이미지 배포 후 E2E 검증 (DELETE → REFUNDED + CANCELLED)
- [ ] (머지 후) CI 빌드 → ArgoCD 자동 sync → 정식 이미지 재검증

## 관련

- 환불 후 좌석 풀 반환을 event-service가 ReservationCancelled outbox로 batch 처리하도록 트리거 활성화
- TOP 5 잔여 작업 #3 (RefundConsumer)의 진짜 해법

Closes #32