### PR TITLE
chore: 분산 트레이싱(OpenTelemetry/Tempo) 제거 (#36)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-    // Tracing (Micrometer + OpenTelemetry Bridge + OTLP Exporter)
-    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
-
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -101,8 +101,6 @@ spec:
                   key: mariadb-password
             - name: TZ
               value: "Asia/Seoul"
-            - name: OTLP_TRACING_ENDPOINT
-              value: "http://alloy-otlp.monitoring:4318/v1/traces"
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION

--- a/src/main/java/com/opentraum/reservation/ReservationServiceApplication.java
+++ b/src/main/java/com/opentraum/reservation/ReservationServiceApplication.java
@@ -7,9 +7,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ReservationServiceApplication {
 
     public static void main(String[] args) {
-        // Reactor Context <-> ThreadLocal 자동 전파. Micrometer Tracing(traceId/spanId)이
-        // Mono/Flux 체인 전반에서 유지되고 MDC로도 흘러가도록 반드시 main 초기에 활성화해야 한다.
-        reactor.core.publisher.Hooks.enableAutomaticContextPropagation();
         SpringApplication.run(ReservationServiceApplication.class, args);
     }
 }

--- a/src/main/java/com/opentraum/reservation/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/reservation/config/KafkaConfig.java
@@ -70,9 +70,6 @@ public class KafkaConfig {
         factory.setConcurrency(3);
         // SAGA consumer가 오프셋을 직접 커밋해 exactly-once 경계를 보장한다.
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
-        // Micrometer Observation 연동: Kafka 레코드 헤더의 W3C traceparent를 읽어
-        // 리스너 실행 동안 동일 trace context로 이어간다.
-        factory.getContainerProperties().setObservationEnabled(true);
         return factory;
     }
 }

--- a/src/main/java/com/opentraum/reservation/domain/outbox/entity/OutboxEvent.java
+++ b/src/main/java/com/opentraum/reservation/domain/outbox/entity/OutboxEvent.java
@@ -44,9 +44,6 @@ public class OutboxEvent {
     @Column("saga_id")
     private String sagaId;
 
-    @Column("trace_id")
-    private String traceId;
-
     private String payload;
 
     @Column("occurred_at")

--- a/src/main/java/com/opentraum/reservation/domain/outbox/service/OutboxService.java
+++ b/src/main/java/com/opentraum/reservation/domain/outbox/service/OutboxService.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opentraum.reservation.domain.outbox.entity.OutboxEvent;
 import com.opentraum.reservation.domain.outbox.repository.OutboxRepository;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -36,14 +33,11 @@ public class OutboxService {
 
     private final OutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
-    private final Tracer tracer;
 
     public OutboxService(OutboxRepository outboxRepository,
-                         ObjectMapper objectMapper,
-                         @Autowired(required = false) Tracer tracer) {
+                         ObjectMapper objectMapper) {
         this.outboxRepository = outboxRepository;
         this.objectMapper = objectMapper;
-        this.tracer = tracer;
     }
 
     /**
@@ -64,7 +58,6 @@ public class OutboxService {
             Map<String, Object> payload
     ) {
         LocalDateTime now = LocalDateTime.now();
-        String traceId = currentTraceId();
 
         Map<String, Object> enriched = new HashMap<>();
         if (payload != null) {
@@ -73,9 +66,6 @@ public class OutboxService {
         enriched.put("saga_id", sagaId);
         enriched.put("reservation_id", aggregateId);
         enriched.put("occurred_at", now.atOffset(ZoneOffset.UTC).format(ISO_MILLIS));
-        if (traceId != null) {
-            enriched.put("trace_id", traceId);
-        }
 
         String payloadJson;
         try {
@@ -91,22 +81,13 @@ public class OutboxService {
                 .aggregateType(aggregateType)
                 .eventType(eventType)
                 .sagaId(sagaId)
-                .traceId(traceId)
                 .payload(payloadJson)
                 .occurredAt(now)
                 .build();
 
         return outboxRepository.save(event)
                 .doOnSuccess(saved -> log.debug(
-                        "Outbox 이벤트 저장 완료: eventId={}, eventType={}, sagaId={}, aggregateId={}, traceId={}",
-                        saved.getEventId(), saved.getEventType(), saved.getSagaId(), saved.getAggregateId(), saved.getTraceId()));
-    }
-
-    private String currentTraceId() {
-        if (tracer == null) {
-            return null;
-        }
-        Span span = tracer.currentSpan();
-        return span != null ? span.context().traceId() : null;
+                        "Outbox 이벤트 저장 완료: eventId={}, eventType={}, sagaId={}, aggregateId={}",
+                        saved.getEventId(), saved.getEventType(), saved.getSagaId(), saved.getAggregateId()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
       mode: always
       schema-locations: classpath:schema.sql
 
-# Actuator + Prometheus + Tracing
+# Actuator + Prometheus
 management:
   endpoints:
     web:
@@ -61,14 +61,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
-  tracing:
-    sampling:
-      probability: 1.0
-    propagation:
-      type: w3c
-  otlp:
-    tracing:
-      endpoint: ${OTLP_TRACING_ENDPOINT:http://alloy.monitoring:4318/v1/traces}
 
 # Queue Properties
 opentraum:
@@ -98,5 +90,3 @@ logging:
     com.opentraum.reservation: DEBUG
     org.springframework.r2dbc: DEBUG
     org.springframework.data.redis: DEBUG
-  pattern:
-    level: "%5p [${spring.application.name:reservation-service},%X{traceId:-},%X{spanId:-}]"

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -42,7 +42,6 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     aggregate_type VARCHAR(64) NOT NULL,
     event_type VARCHAR(64) NOT NULL,
     saga_id CHAR(36) NOT NULL,
-    trace_id CHAR(32),
     payload JSON NOT NULL,
     occurred_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     INDEX idx_outbox_aggregate (aggregate_type, aggregate_id),


### PR DESCRIPTION
## 개요

이슈 #36 - reservation-service에 남아 있던 OpenTelemetry / Tempo 분산 트레이싱 흔적을 의존성, 설정, 코드, DB 스키마에서 모두 제거합니다.

## 변경 파일

- `build.gradle`
  - `io.micrometer:micrometer-tracing-bridge-otel` 의존성 제거
  - `io.opentelemetry:opentelemetry-exporter-otlp` 의존성 제거
- `ReservationServiceApplication.java`
  - `Hooks.enableAutomaticContextPropagation()` 호출 및 관련 주석 제거
- `application.yml`
  - `management.tracing` 블록 제거
  - `management.otlp.tracing` 블록 제거
  - `logging.pattern.level`에서 `%X{traceId:-},%X{spanId:-}` 제거
- `OutboxEvent.java`
  - `traceId` 필드와 `@Column("trace_id")` 제거
- `OutboxService.java`
  - `Tracer` 의존성 제거
  - `currentTraceId()` 메서드 제거
  - 빌더의 `.traceId(traceId)` 호출 제거
  - payload enrich 로직에서 `enriched.put("trace_id", traceId)` 제거
  - 로그 포맷의 `traceId={}` placeholder와 인자 제거
- `schema.sql`
  - `outbox_events.trace_id` 컬럼 제거

## 영향

- 트레이싱 정보가 더 이상 수집되거나 저장되지 않습니다.
- 발행되는 이벤트 payload에서 `trace_id` 필드가 사라집니다 (event-service, payment-service 컨슈머는 해당 필드를 사용하지 않음).
- `outbox_events` 테이블 스키마가 변경되므로 기존 DB는 폐기 후 재생성합니다 (운영 데이터 아님).
- 관측성은 Prometheus(metrics)와 Loki(logs) 조합으로 단순화됩니다.

## 검증

- [ ] `./gradlew compileJava` 통과
- [ ] mariadb reservation DB 재생성 (PVC 삭제 + StatefulSet 재기동)
- [ ] 파드 정상 기동 및 outbox 발행 정상 확인

Closes #36