### PR TITLE
fix: seat-assignment 기반 lottery 결제 상태 전이 연결

### DIFF
--- a/src/main/java/com/opentraum/reservation/domain/service/LotteryTrackService.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/LotteryTrackService.java
@@ -170,13 +170,32 @@ public class LotteryTrackService {
     public Mono<Void> onPaymentCompleted(Long reservationId, Long userId, Long scheduleId) {
         String lotteryPaidKey = RedisKeyGenerator.lotteryPaidKey(scheduleId);
         return reservationRepository.findById(reservationId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.RESERVATION_NOT_FOUND)))
                 .flatMap(reservation -> {
+                    if (!TrackType.LOTTERY.name().equals(reservation.getTrackType())) {
+                        log.warn("seat-assignment ignored for non-lottery reservation: reservationId={}, track={}",
+                                reservationId, reservation.getTrackType());
+                        return Mono.<Reservation>empty();
+                    }
+                    String status = reservation.getStatus();
+                    if (ReservationStatus.PAID_PENDING_SEAT.name().equals(status)
+                            || ReservationStatus.ASSIGNED.name().equals(status)) {
+                        return Mono.just(reservation);
+                    }
+                    if (ReservationStatus.CANCELLED.name().equals(status)
+                            || ReservationStatus.REFUNDED.name().equals(status)) {
+                        log.warn("seat-assignment ignored for closed reservation: reservationId={}, status={}",
+                                reservationId, status);
+                        return Mono.<Reservation>empty();
+                    }
                     reservation.setStatus(ReservationStatus.PAID_PENDING_SEAT.name());
                     reservation.setUpdatedAt(LocalDateTime.now());
                     return reservationRepository.save(reservation);
                 })
-                .then(redisTemplate.opsForSet().add(lotteryPaidKey, userId.toString()))
-                .doOnSuccess(v -> log.info("추첨 결제 완료: reservationId={}, userId={}", reservationId, userId))
+                .flatMap(reservation -> redisTemplate.opsForSet()
+                        .add(lotteryPaidKey, userId.toString())
+                        .thenReturn(reservation))
+                .doOnNext(v -> log.info("추첨 결제 완료: reservationId={}, userId={}", reservationId, userId))
                 .then();
     }
 

--- a/src/main/java/com/opentraum/reservation/domain/service/SeatAssignmentConsumer.java
+++ b/src/main/java/com/opentraum/reservation/domain/service/SeatAssignmentConsumer.java
@@ -1,32 +1,101 @@
 package com.opentraum.reservation.domain.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opentraum.reservation.global.config.KafkaTopics;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.KafkaHeaders;
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 /**
- * seat-assignment 토픽 Consumer 뼈대
- * 실제 좌석 배정 로직 연결은 추후 이슈에서 진행
+ * seat-assignment 토픽 Consumer.
+ *
+ * <p>legacy 직접 Kafka 경로에서 전달되는 lottery 결제 완료 신호를 reservation 상태 전이에 연결한다.
+ * 실제 좌석 배정은 기존 스케줄러가 결제 마감 이후 {@link LotteryTrackService#assignSeatsToPaidLotteryAndMerge}
+ * 로 수행한다.
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SeatAssignmentConsumer {
+
+    private static final String CONSUMER_GROUP = "reservation-seat-assignment-group";
+
+    private final ObjectMapper objectMapper;
+    private final LotteryTrackService lotteryTrackService;
 
     @KafkaListener(
             topics = KafkaTopics.SEAT_ASSIGNMENT,
-            groupId = "${spring.kafka.consumer.group-id}"
+            groupId = CONSUMER_GROUP
     )
-    public void handleSeatAssignment(
-            @Payload String message,
-            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-            @Header(KafkaHeaders.OFFSET) long offset) {
+    public void handleSeatAssignment(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        String message = record.value();
         log.info("[Kafka] seat-assignment 수신: topic={}, offset={}, message={}",
-                topic, offset, message);
+                record.topic(), record.offset(), message);
 
-        // TODO: 실제 좌석 배정 로직 연결 (추후 이슈)
+        handle(message)
+                .subscribe(
+                        ignored -> {
+                        },
+                        e -> log.error("[Kafka] seat-assignment 처리 실패: offset={}, err={}",
+                                record.offset(), e.getMessage(), e),
+                        ack::acknowledge);
+    }
+
+    private Mono<Void> handle(String message) {
+        JsonNode node;
+        try {
+            node = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("[Kafka] seat-assignment payload 파싱 실패: message={}", message, e);
+            return Mono.empty();
+        }
+
+        Long reservationId = longOrNull(node, "reservationId", "reservation_id");
+        Long userId = longOrNull(node, "userId", "user_id");
+        Long scheduleId = longOrNull(node, "scheduleId", "schedule_id");
+
+        if (reservationId == null || userId == null || scheduleId == null) {
+            log.warn("[Kafka] seat-assignment 필수 필드 누락: reservationId={}, userId={}, scheduleId={}",
+                    reservationId, userId, scheduleId);
+            return Mono.empty();
+        }
+
+        return lotteryTrackService.onPaymentCompleted(reservationId, userId, scheduleId);
+    }
+
+    private static Long longOrNull(JsonNode node, String... fields) {
+        for (String field : fields) {
+            JsonNode value = node.get(field);
+            if (value != null && !value.isNull()) {
+                Long parsed = parseLong(value);
+                if (parsed != null) {
+                    return parsed;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Long parseLong(JsonNode value) {
+        if (value.isIntegralNumber()) {
+            return value.longValue();
+        }
+        if (value.isTextual()) {
+            String text = value.asText();
+            if (text == null || text.isBlank()) {
+                return null;
+            }
+            try {
+                return Long.valueOf(text);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/com/opentraum/reservation/domain/service/LotteryTrackServiceTest.java
+++ b/src/test/java/com/opentraum/reservation/domain/service/LotteryTrackServiceTest.java
@@ -1,0 +1,98 @@
+package com.opentraum.reservation.domain.service;
+
+import com.opentraum.reservation.domain.client.EventServiceClient;
+import com.opentraum.reservation.domain.entity.Reservation;
+import com.opentraum.reservation.domain.entity.ReservationStatus;
+import com.opentraum.reservation.domain.entity.TrackType;
+import com.opentraum.reservation.domain.outbox.service.OutboxService;
+import com.opentraum.reservation.domain.queue.service.QueueTokenService;
+import com.opentraum.reservation.domain.repository.ReservationRepository;
+import com.opentraum.reservation.domain.repository.ReservationSeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveSetOperations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LotteryTrackServiceTest {
+
+    private final ReservationRepository reservationRepository = mock(ReservationRepository.class);
+    private final ReservationSeatRepository reservationSeatRepository = mock(ReservationSeatRepository.class);
+    private final EventServiceClient eventServiceClient = mock(EventServiceClient.class);
+    private final ReactiveRedisTemplate<String, String> redisTemplate = mock(ReactiveRedisTemplate.class);
+    private final ReactiveSetOperations<String, String> setOperations = mock(ReactiveSetOperations.class);
+    private final QueueTokenService queueTokenService = mock(QueueTokenService.class);
+    private final OutboxService outboxService = mock(OutboxService.class);
+
+    private LotteryTrackService service;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+        when(setOperations.add("lottery-paid:30", "20")).thenReturn(Mono.just(1L));
+        service = new LotteryTrackService(
+                reservationRepository,
+                reservationSeatRepository,
+                eventServiceClient,
+                redisTemplate,
+                queueTokenService,
+                outboxService);
+    }
+
+    @Test
+    void paymentCompletedMovesPendingLotteryReservationToPaidPendingSeat() {
+        Reservation reservation = reservation(ReservationStatus.PENDING.name(), TrackType.LOTTERY.name());
+        when(reservationRepository.findById(10L)).thenReturn(Mono.just(reservation));
+        when(reservationRepository.save(reservation)).thenReturn(Mono.just(reservation));
+
+        StepVerifier.create(service.onPaymentCompleted(10L, 20L, 30L))
+                .verifyComplete();
+
+        verify(reservationRepository).save(reservation);
+        verify(setOperations).add("lottery-paid:30", "20");
+        org.assertj.core.api.Assertions.assertThat(reservation.getStatus())
+                .isEqualTo(ReservationStatus.PAID_PENDING_SEAT.name());
+    }
+
+    @Test
+    void paymentCompletedIsIdempotentForAlreadyPaidPendingSeatReservation() {
+        Reservation reservation = reservation(ReservationStatus.PAID_PENDING_SEAT.name(), TrackType.LOTTERY.name());
+        when(reservationRepository.findById(10L)).thenReturn(Mono.just(reservation));
+
+        StepVerifier.create(service.onPaymentCompleted(10L, 20L, 30L))
+                .verifyComplete();
+
+        verify(reservationRepository, never()).save(any());
+        verify(setOperations).add("lottery-paid:30", "20");
+    }
+
+    @Test
+    void paymentCompletedIgnoresClosedReservationWithoutSideEffects() {
+        Reservation reservation = reservation(ReservationStatus.CANCELLED.name(), TrackType.LOTTERY.name());
+        when(reservationRepository.findById(10L)).thenReturn(Mono.just(reservation));
+
+        StepVerifier.create(service.onPaymentCompleted(10L, 20L, 30L))
+                .verifyComplete();
+
+        verify(reservationRepository, never()).save(any());
+        verify(setOperations, never()).add(eq("lottery-paid:30"), eq("20"));
+    }
+
+    private static Reservation reservation(String status, String trackType) {
+        return Reservation.builder()
+                .id(10L)
+                .userId(20L)
+                .scheduleId(30L)
+                .trackType(trackType)
+                .status(status)
+                .build();
+    }
+}

--- a/src/test/java/com/opentraum/reservation/domain/service/SeatAssignmentConsumerTest.java
+++ b/src/test/java/com/opentraum/reservation/domain/service/SeatAssignmentConsumerTest.java
@@ -1,0 +1,77 @@
+package com.opentraum.reservation.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.support.Acknowledgment;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SeatAssignmentConsumerTest {
+
+    private final LotteryTrackService lotteryTrackService = mock(LotteryTrackService.class);
+    private final SeatAssignmentConsumer consumer = new SeatAssignmentConsumer(new ObjectMapper(), lotteryTrackService);
+
+    @Test
+    void handlesCamelCaseSeatAssignmentPayload() {
+        when(lotteryTrackService.onPaymentCompleted(10L, 20L, 30L)).thenReturn(Mono.empty());
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.handleSeatAssignment(record("{\"reservationId\":10,\"userId\":20,\"scheduleId\":30}"), ack);
+
+        verify(lotteryTrackService).onPaymentCompleted(10L, 20L, 30L);
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void handlesSnakeCaseSeatAssignmentPayload() {
+        when(lotteryTrackService.onPaymentCompleted(10L, 20L, 30L)).thenReturn(Mono.empty());
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.handleSeatAssignment(record("{\"reservation_id\":10,\"user_id\":20,\"schedule_id\":30}"), ack);
+
+        verify(lotteryTrackService).onPaymentCompleted(10L, 20L, 30L);
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void acknowledgesAndSkipsMalformedPayload() {
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.handleSeatAssignment(record("not-json"), ack);
+
+        verify(lotteryTrackService, never()).onPaymentCompleted(anyLong(), anyLong(), anyLong());
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    void doesNotAcknowledgeWhenProcessingFails() {
+        when(lotteryTrackService.onPaymentCompleted(10L, 20L, 30L))
+                .thenReturn(Mono.error(new IllegalStateException("redis-unavailable")));
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.handleSeatAssignment(record("{\"reservationId\":10,\"userId\":20,\"scheduleId\":30}"), ack);
+
+        verify(lotteryTrackService).onPaymentCompleted(10L, 20L, 30L);
+        verify(ack, never()).acknowledge();
+    }
+
+    @Test
+    void acknowledgesAndSkipsNonNumericIds() {
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.handleSeatAssignment(record("{\"reservationId\":\"abc\",\"userId\":20,\"scheduleId\":30}"), ack);
+
+        verify(lotteryTrackService, never()).onPaymentCompleted(anyLong(), anyLong(), anyLong());
+        verify(ack).acknowledge();
+    }
+
+    private static ConsumerRecord<String, String> record(String value) {
+        return new ConsumerRecord<>("seat-assignment", 0, 7L, "10", value);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- `seat-assignment` Kafka consumer를 실제 lottery 결제 완료 상태 전이에 연결했습니다.
- camelCase/snake_case payload를 모두 처리하도록 파싱을 보강했습니다.
- 필수 ID 누락 또는 잘못된 숫자 payload는 ack 후 skip하고, 실제 처리 실패는 ack하지 않도록 했습니다.
- lottery 예약 결제 완료 반영을 idempotent하게 만들고, 취소/환불 등 닫힌 예약에는 부작용을 만들지 않도록 했습니다.
- consumer 처리/ack 정책과 lottery 상태 전이를 회귀 테스트로 고정했습니다.

## 배경 / 원인

`seat-assignment` legacy Kafka 경로가 로그만 남기고 실제 reservation 상태 전이에 연결되지 않아 lottery 결제 완료 후 좌석 배정 전 상태가 안정적으로 이어지지 않는 문제가 있었습니다. 또한 처리 실패 시 ack하면 메시지가 유실될 수 있어 재처리 가능성을 보장해야 했습니다.

## 팀 공유사항

- malformed payload와 필수 필드 누락은 재처리해도 회복되지 않는 입력 오류로 보고 ack 후 skip합니다.
- Redis/DB 등 실제 처리 실패는 ack하지 않습니다. 이 경우 Kafka 재처리 대상입니다.
- `PAID_PENDING_SEAT`, `ASSIGNED` 상태는 idempotent하게 처리합니다.
- `CANCELLED`, `REFUNDED` 상태에는 Redis lottery-paid set 추가를 하지 않습니다.
- 수동 K8s 배포 이미지 기준 E2E/API는 `74/74` 통과했지만, 이후 ArgoCD selfHeal 복구로 현재 클러스터 이미지는 GitOps 기준 이미지로 되돌아간 상태입니다. 이 PR이 merge되어야 같은 변경이 GitOps 배포에 반영됩니다.

## 검증

- `./gradlew test` 통과
- `./gradlew bootJar` 통과
- 수동 배포 이미지 기준 K8s E2E/API `74/74` 통과

## 영향 범위

- reservation-service lottery 예약 상태 전이
- `seat-assignment` Kafka consumer ack 정책
- 결제 완료 이후 lottery 좌석 배정 준비 상태

## 관련 이슈

- Related: #35
