### PR TITLE
chore: #43 Pod 자원 재산정 + 불필요한 wait-for-payment init container 제거

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -56,24 +56,6 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/part-of: opentraum
-      initContainers:
-        - name: wait-for-payment
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - >
-              echo Waiting for payment-service...;
-              until wget -qO- http://payment-service:8085/actuator/health 2>/dev/null | grep -q UP;
-              do echo payment not ready; sleep 3; done;
-              echo payment-service is ready!
-          resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
-            limits:
-              cpu: 10m
-              memory: 32Mi
       containers:
         - name: reservation-service
           image: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com/skala3-cloud1-team8-opentraum-reservation-service:33f43e534b50a172e4ff516d88d3b6e451b8567a

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -106,8 +106,8 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "200m"
             limits:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "200m"
       restartPolicy: Always


### PR DESCRIPTION
Closes #43

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `500m` → `200m`
- `resources.requests.memory`: `512Mi` 유지
- `resources.limits.cpu`: `500m` → `200m`
- `resources.limits.memory`: `512Mi` 유지
- `initContainers.wait-for-payment` 블록 제거

## 영향
- QoS: `Guaranteed` 유지
- CPU request 절감: -300m
- init container 제거로 Pod 기동이 payment-service 상태에 묶이지 않음
- init container 자원 회수: cpu 10m / memory 32Mi
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 1개 교체 (`maxSurge: 1`, `maxUnavailable: 0`)
